### PR TITLE
Allow crystal 1.0.0

### DIFF
--- a/shard.yml
+++ b/shard.yml
@@ -4,14 +4,14 @@ version: 0.4.0
 authors:
   - Roman Kalnytskyi <moranibaca@gmail.com>
 
-crystal: 0.35.1
+crystal: '>= 0.35.1'
 
 license: MIT
 
 development_dependencies:
   ameba:
     github: crystal-ameba/ameba
-    version: "= 0.13.0"
+    version: "~> 0.14.0"
 
 scripts:
   postinstall: "false | [ -f ../../sam.cr ]  && true || cp -i examples/sam.template ../../sam.cr 2>/dev/null"


### PR DESCRIPTION
* Update Crystal version
* Update amoeba version appropriately to go along with Crystal

This is a temporary improvement to this fork until we get the skip-tasks work merged into the upstream sam.cr repo.

## Specs

We have a failing test. But this is also failing on the main branch. So I think it should be ok for now.
![image](https://user-images.githubusercontent.com/84005/127341979-c8cce237-25e9-4cc1-a4d9-c85b0bf1d227.png)
